### PR TITLE
Capitalized menu text

### DIFF
--- a/menus/atomerinal.cson
+++ b/menus/atomerinal.cson
@@ -22,6 +22,6 @@
   '.tree-view.full-menu': [
     {'type': 'separator'}
     {'label': 'Open Terminal Here', 'command': 'atomerinal:open-terminal-treeview'}
-    {'label': 'Open Terminal in Project Root', 'command': 'atomerinal:open-terminal-treeview-root'}
+    {'label': 'Open Terminal In Project Root', 'command': 'atomerinal:open-terminal-treeview-root'}
     {'type': 'separator'}
   ]

--- a/menus/atomerinal.cson
+++ b/menus/atomerinal.cson
@@ -6,11 +6,11 @@
       'label': 'Atomerinal'
       'submenu': [
         {
-          'label': 'Open terminal here'
+          'label': 'Open Terminal Here'
           'command': 'atomerinal:open-terminal-here'
         },
         {
-          'label': 'Open terminal in project root'
+          'label': 'Open Terminal in Project Root'
           'command': 'atomerinal:open-terminal-in-root'
         }
       ]
@@ -21,7 +21,7 @@
 'context-menu':
   '.tree-view.full-menu': [
     {'type': 'separator'}
-    {'label': 'Open terminal here', 'command': 'atomerinal:open-terminal-treeview'}
-    {'label': 'Open terminal in root', 'command': 'atomerinal:open-terminal-treeview-root'}
+    {'label': 'Open Terminal Here', 'command': 'atomerinal:open-terminal-treeview'}
+    {'label': 'Open Terminal in Project Root', 'command': 'atomerinal:open-terminal-treeview-root'}
     {'type': 'separator'}
   ]

--- a/menus/atomerinal.cson
+++ b/menus/atomerinal.cson
@@ -10,7 +10,7 @@
           'command': 'atomerinal:open-terminal-here'
         },
         {
-          'label': 'Open Terminal in Project Root'
+          'label': 'Open Terminal In Project Root'
           'command': 'atomerinal:open-terminal-in-root'
         }
       ]


### PR DESCRIPTION
Capitalized menu text for 'Open Terminal Here' and 'Open Terminal in Project Root' to align it with Atom's convention.
